### PR TITLE
Use a better name so LLM can recognize staff name

### DIFF
--- a/configs/query_engine/weekly_report_trend_summary.py
+++ b/configs/query_engine/weekly_report_trend_summary.py
@@ -43,15 +43,16 @@ def generate_report_summary(messages_history):
             'reference': ref,
             'from_fields': list(set(msg['from_field'] for msg in conversations)),
             'to_fields': list(set(msg['to_field'] for msg in conversations)),
-            'sender_name': next(
+            'staff_name': next(
                 (msg['sender_name'] for msg in conversations if msg['from_field'] == BROADCAST_SOURCE_PHONE_NUMBER),
                 None
             ),
-            'sender_email': next(
+            'staff_email': next(
                 (msg['sender_email'] for msg in conversations if msg['from_field'] == BROADCAST_SOURCE_PHONE_NUMBER),
                 None
             )
         }
+        print(metadata)
         doc = Document(
             text=conversation_text,
             metadata=metadata


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated terminology in the report summary metadata for consistency (renamed 'sender_name' to 'staff_name' and 'sender_email' to 'staff_email').
  
- **Chores**
	- Added a debug output for the metadata dictionary to assist with troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->