### PR TITLE
[DEBUG] Get last 3 weeks data for testing, remove later

### DIFF
--- a/services/analytics/queries.py
+++ b/services/analytics/queries.py
@@ -49,7 +49,7 @@ GET_WEEKLY_MESSAGES_HISTORY = """
             SELECT tm.*, u.name, u.email
             FROM public.twilio_messages tm LEFT JOIN public.users u on tm.sender_id = u.id
             WHERE 
-            tm.created_at >= DATE_TRUNC('week', CURRENT_DATE) - INTERVAL '1 week'
+            tm.created_at >= DATE_TRUNC('week', CURRENT_DATE) - INTERVAL '3 week'
             AND 
             tm.created_at < DATE_TRUNC('week', CURRENT_DATE)
         """


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Extended the time frame for retrieving weekly message history from 1 week to 3 weeks, allowing users to access a broader range of historical data. 

- **Bug Fixes**
	- Adjusted SQL query to improve data aggregation for message history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->