### PR TITLE
OUT-363 - Remove Broadcast Segment and Unsubscribe Breakdowns from Weekly Report

### DIFF
--- a/services/analytics/queries.py
+++ b/services/analytics/queries.py
@@ -6,18 +6,12 @@ from services.analytics.config import (
     AUTOMATED_SENDER_IDS,
 )
 
-GET_WEEKLY_UNSUBSCRIBE_BY_AUDIENCE_SEGMENT = text("""
-    SELECT 
-        asg.id,
-        asg.name as audience_segment_name,
-        COUNT(distinct bsms.recipient_phone_number) AS count
+GET_WEEKLY_TOTAL_UNSUBSCRIBES = text("""
+    SELECT COUNT(DISTINCT bsms.recipient_phone_number) AS count
     FROM public.unsubscribed_messages um 
     INNER JOIN public.message_statuses bsms 
         ON um.reply_to = bsms.id
-    INNER JOIN public.audience_segments asg 
-        ON bsms.audience_segment_id = asg.id
-    WHERE um.created_at >= DATE_TRUNC('week', CURRENT_DATE) - INTERVAL '1 week'  
-    GROUP BY asg.id
+    WHERE um.created_at >= DATE_TRUNC('week', CURRENT_DATE) - INTERVAL '1 week'
 """)
 
 GET_WEEKLY_BROADCAST_SENT = text("""
@@ -39,13 +33,13 @@ GET_WEEKLY_BROADCAST_STARTERS = text("""
 """)
 
 GET_WEEKLY_MESSAGES_HISTORY = """
-            SELECT tm.*, u.name, u.email
-            FROM public.twilio_messages tm LEFT JOIN public.users u on tm.sender_id = u.id
-            WHERE 
-            tm.created_at >= DATE_TRUNC('week', CURRENT_DATE) - INTERVAL '1 week'
-            AND 
-            tm.created_at < DATE_TRUNC('week', CURRENT_DATE)
-        """
+    SELECT tm.*, u.name, u.email
+    FROM public.twilio_messages tm LEFT JOIN public.users u on tm.sender_id = u.id
+    WHERE 
+    tm.created_at >= DATE_TRUNC('week', CURRENT_DATE) - INTERVAL '1 week'
+    AND 
+    tm.created_at < DATE_TRUNC('week', CURRENT_DATE)
+"""
 
 GET_WEEKLY_FAILED_MESSAGE = text("""
     SELECT COUNT(DISTINCT recipient_phone_number) AS count
@@ -76,17 +70,14 @@ GET_WEEKLY_IMPACT_CONVERSATIONS = lambda impact_label_ids: text(f"""
     GROUP BY l.name;
 """)
 
-GET_WEEKLY_REPLIES_BY_AUDIENCE_SEGMENT = text("""
-    SELECT asg.id, asg.name as audience_segment_name, COUNT(distinct tm.from_field) as count
+GET_WEEKLY_TOTAL_REPLIES = text("""
+    SELECT COUNT(DISTINCT tm.from_field) as count
     FROM public.twilio_messages tm 
     LEFT JOIN public.message_statuses bsms 
         ON tm.reply_to_broadcast = bsms.broadcast_id 
         AND tm.from_field = bsms.recipient_phone_number
-    INNER JOIN public.audience_segments asg 
-        ON bsms.audience_segment_id = asg.id
     WHERE tm.reply_to_broadcast IS NOT NULL
-        AND tm.created_at >= DATE_TRUNC('week', CURRENT_DATE) - INTERVAL '1 week'  
-    GROUP BY asg.id
+        AND tm.created_at >= DATE_TRUNC('week', CURRENT_DATE) - INTERVAL '1 week'
 """)
 
 GET_WEEKLY_REPORTER_CONVERSATION = text(f"""

--- a/services/analytics/service.py
+++ b/services/analytics/service.py
@@ -9,11 +9,11 @@ from libs.MissiveAPI import MissiveAPI
 from models import WeeklyReport
 from services.analytics.config import IMPACT_LABEL_IDS
 from services.analytics.queries import (
-    GET_WEEKLY_UNSUBSCRIBE_BY_AUDIENCE_SEGMENT,
+    GET_WEEKLY_TOTAL_UNSUBSCRIBES,
     GET_WEEKLY_FAILED_MESSAGE,
     GET_WEEKLY_TEXT_INS,
     GET_WEEKLY_IMPACT_CONVERSATIONS,
-    GET_WEEKLY_REPLIES_BY_AUDIENCE_SEGMENT,
+    GET_WEEKLY_TOTAL_REPLIES,
     GET_WEEKLY_REPORTER_CONVERSATION,
     GET_WEEKLY_DATA_LOOKUP,
     GET_WEEKLY_TOP_ZIP_CODE,
@@ -24,19 +24,16 @@ from services.analytics.queries import (
 from services.analytics.utils import (
     process_conversation_metrics,
     process_conversation_outcomes,
-    process_audience_segment_related_data,
     process_lookup_history,
     generate_geographic_region_markdown,
-    generate_data_by_audience_segment_markdown,
     generate_conversation_outcomes_markdown,
     generate_lookup_history_markdown,
     generate_intro_section,
-    generate_major_themes_section,
     generate_conversation_metrics_section,
     format_weekly_report_data,
     calculate_percentage_change,
     FetchDataResult,
-    generate_broadcast_info_section, get_conversation_id,
+    generate_broadcast_info_section, get_conversation_id, generate_major_themes_section,
 )
 
 load_dotenv(override=True)
@@ -46,8 +43,8 @@ class AnalyticsService:
     def __init__(self):
         self.Session = Session()
 
-    def get_weekly_unsubscribe_by_audience_segment(self, session):
-        return session.execute(GET_WEEKLY_UNSUBSCRIBE_BY_AUDIENCE_SEGMENT).fetchall()
+    def get_weekly_total_unsubscribes(self, session):
+        return session.execute(GET_WEEKLY_TOTAL_UNSUBSCRIBES).fetchall()
 
     def get_weekly_broadcast_sent(self, session):
         return session.execute(GET_WEEKLY_BROADCAST_CONTENT).fetchall()
@@ -104,8 +101,8 @@ class AnalyticsService:
         impact_label_ids = ", ".join(f"'{id}'" for id in IMPACT_LABEL_IDS)
         return session.execute(GET_WEEKLY_IMPACT_CONVERSATIONS(impact_label_ids)).fetchall()
 
-    def get_weekly_replies_by_audience_segment(self, session):
-        return session.execute(GET_WEEKLY_REPLIES_BY_AUDIENCE_SEGMENT).fetchall()
+    def get_weekly_total_replies(self, session):
+        return session.execute(GET_WEEKLY_TOTAL_REPLIES).fetchall()
 
     def get_weekly_reporter_conversation(self, session):
         return session.execute(GET_WEEKLY_REPORTER_CONVERSATION).fetchall()
@@ -147,14 +144,14 @@ class AnalyticsService:
     def fetch_data(self):
         with self.Session as session:
             # Fetch all the data here synchronously
-            unsubscribed_messages = self.get_weekly_unsubscribe_by_audience_segment(session)
+            unsubscribed_messages = self.get_weekly_total_unsubscribes(session)
             broadcasts = self.get_weekly_broadcast_sent(session)
             broadcast_starters = self.get_broadcasts_starters(session, broadcasts)
             messages_history = self.get_weekly_messages_history(session, broadcasts)
             failed_deliveries = self.get_weekly_failed_message(session)
             text_ins = self.get_weekly_text_ins(session)
             impact_conversations = self.get_weekly_impact_conversations(session)
-            replies = self.get_weekly_replies_by_audience_segment(session)
+            replies = self.get_weekly_total_replies(session)
             report_conversations = self.get_weekly_reporter_conversation(session)
             lookup_history = self.get_weekly_data_look_up(session)
             zip_codes = self.get_weekly_top_zip_code(session)
@@ -182,8 +179,8 @@ class AnalyticsService:
         conversation_metrics,
         conversation_outcomes,
         property_statuses,
-        broadcast_replies,
-        unsubscribes,
+        total_broadcast_replies,
+        total_unsubscribes,
     ):
         new_report = WeeklyReport(
             created_at=current_date,
@@ -206,18 +203,8 @@ class AnalyticsService:
             status_no_tax_debt=property_statuses["NO_TAX_DEBT"],
             status_compliant=property_statuses["COMPLIANT"],
             status_foreclosed=property_statuses["FORECLOSED"],
-            replies_total=sum(broadcast_replies.values()),
-            replies_proactive=broadcast_replies["Proactive"],
-            replies_receptive=broadcast_replies["Receptive"],
-            replies_connected=broadcast_replies["Connected"],
-            replies_passive=broadcast_replies["Passive"],
-            replies_inactive=broadcast_replies["Inactive"],
-            unsubscribes_total=sum(unsubscribes.values()),
-            unsubscribes_proactive=unsubscribes["Proactive"],
-            unsubscribes_receptive=unsubscribes["Receptive"],
-            unsubscribes_connected=unsubscribes["Connected"],
-            unsubscribes_passive=unsubscribes["Passive"],
-            unsubscribes_inactive=unsubscribes["Inactive"],
+            replies_total=total_broadcast_replies,
+            unsubscribes_total=total_unsubscribes,
         )
         session.add(new_report)
         session.commit()
@@ -231,15 +218,12 @@ class AnalyticsService:
         conversation_metrics = process_conversation_metrics(data)
         property_statuses = process_lookup_history(data["lookup_history"])
         conversations_outcomes = process_conversation_outcomes(data["impact_conversations"])
-        replies_by_audience_segment = process_audience_segment_related_data(data["replies"])
-        unsubscribes_by_audience_segment = process_audience_segment_related_data(
-            data["unsubscribed_messages"]
-        )
 
         intro_section = generate_intro_section()
         broadcast_and_summary_section = generate_broadcast_info_section(data["broadcasts_content"])
         major_themes_section = generate_major_themes_section(data["messages_history"])
         zip_code_section = generate_geographic_region_markdown(data["zip_codes"])
+
         conversation_metrics_section = generate_conversation_metrics_section(
             conversation_metrics,
             calculate_percentage_change(
@@ -263,26 +247,7 @@ class AnalyticsService:
                 last_4_week_data["conversation_outcomes"], conversations_outcomes
             ),
         )
-        replies_by_audience_segment_section = generate_data_by_audience_segment_markdown(
-            "Broadcast Replies by Audience Segment",
-            replies_by_audience_segment,
-            calculate_percentage_change(last_week_data["replies"], replies_by_audience_segment),
-            calculate_percentage_change(last_4_week_data["replies"], replies_by_audience_segment),
-        )
-        unsubscribe_by_audience_segment_section = generate_data_by_audience_segment_markdown(
-            "Broadcast Unsubscribes by Audience Segment",
-            unsubscribes_by_audience_segment,
-            calculate_percentage_change(
-                last_week_data["unsubscribed_messages"], unsubscribes_by_audience_segment
-            ),
-            calculate_percentage_change(
-                last_4_week_data["unsubscribed_messages"], unsubscribes_by_audience_segment
-            ),
-        )
-
-        markdown_report = [
-            intro_section,
-        ]
+        markdown_report = [intro_section]
 
         if major_themes_section:
             markdown_report.append(major_themes_section)
@@ -296,17 +261,10 @@ class AnalyticsService:
             markdown_report.append(zip_code_section)
         if conversation_outcomes_section:
             markdown_report.append(conversation_outcomes_section)
-        if replies_by_audience_segment_section:
-            markdown_report.append(replies_by_audience_segment_section)
-        if unsubscribe_by_audience_segment_section:
-            markdown_report.append(unsubscribe_by_audience_segment_section)
 
         conversation_id = get_conversation_id(self.Session)
         missive_client = MissiveAPI()
-        missive_client.send_post_sync(
-            markdown_report, conversation_id=conversation_id
-        )
-
+        missive_client.send_post_sync(markdown_report, conversation_id=conversation_id)
         with self.Session as session:
             self.insert_weekly_report(
                 session,
@@ -314,8 +272,8 @@ class AnalyticsService:
                 conversation_metrics,
                 conversations_outcomes,
                 property_statuses,
-                replies_by_audience_segment,
-                unsubscribes_by_audience_segment,
+                data["replies"][0][0],
+                data["unsubscribed_messages"][0][0],
             )
 
     def fetch_average_data_last_4_weeks(self):

--- a/services/analytics/utils.py
+++ b/services/analytics/utils.py
@@ -145,20 +145,6 @@ def process_conversation_outcomes(outcomes):
     return outcome_counts
 
 
-def process_audience_segment_related_data(data):
-    # Initialize the segment counts
-    segment_counts = {"Proactive": 0, "Receptive": 0, "Connected": 0, "Passive": 0, "Inactive": 0}
-
-    # Map the fetched data to segment_counts
-    for row in data:
-        segment_name = row["audience_segment_name"]
-        if segment_name in segment_counts:
-            count = row["count"]
-            segment_counts[segment_name] = count
-
-    return segment_counts
-
-
 def generate_geographic_region_markdown(zip_codes):
     zip_code_section = format_geographic_regions(zip_codes)
     if zip_code_section.strip():
@@ -197,19 +183,6 @@ def generate_conversation_outcomes_markdown(outcome_counts, percentage_changes, 
         f"| Source                        | {outcome_counts['source']} |   {format_percentage_change(percentage_changes['source'])} |  {format_percentage_change(percentage_changes_4_week['source'])} \n"
         f"| Unsatisfied                    | {outcome_counts['unsatisfied']} |   {format_percentage_change(percentage_changes['unsatisfied'])} |  {format_percentage_change(percentage_changes_4_week['unsatisfied'])} \n"
         f"| Future Keyword                | {outcome_counts['future keyword']} |   {format_percentage_change(percentage_changes['future keyword'])} | {format_percentage_change(percentage_changes_4_week['future keyword'])} \n"
-    )
-
-
-def generate_data_by_audience_segment_markdown(title, segment_counts, percentage_changes, percentage_changes_4_week):
-    return (
-        f"### {title}\n"
-        "| Segment                         | Count |  Change (weekly) | Change (4-weeks avg) |\n"
-        "|-------------------------------  |-------|----------------|---------------------|\n"
-        f"| Proactive              | {segment_counts['Proactive']}|   {format_percentage_change(percentage_changes['Proactive'])}  | {format_percentage_change(percentage_changes_4_week['Proactive'])}  \n"
-        f"| Receptive             | {segment_counts['Receptive']}|   {format_percentage_change(percentage_changes['Receptive'])}   | {format_percentage_change(percentage_changes_4_week['Receptive'])}   \n"
-        f"| Connected                | {segment_counts['Connected']}|   {format_percentage_change(percentage_changes['Connected'])}  | {format_percentage_change(percentage_changes_4_week['Connected'])}  \n"
-        f"| Passive            | {segment_counts['Passive']}|   {format_percentage_change(percentage_changes['Passive'])}  | {format_percentage_change(percentage_changes_4_week['Passive'])}  \n"
-        f"| Inactive                        | {segment_counts['Inactive']}|   {format_percentage_change(percentage_changes['Inactive'])}  | {format_percentage_change(percentage_changes_4_week['Inactive'])}  \n"
     )
 
 


### PR DESCRIPTION
Co-authored-by: Thuan Ngo <thuan.ngo@eastagile.com>

[OUT-363](https://linear.app/pdw/issue/OUT-363/remove-broadcast-segment-and-unsubscribe-breakdowns-from-weekly-report)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Consolidated analytics metrics to display overall totals for unsubscribes and replies instead of segmented counts.
  - Streamlined weekly reporting by removing detailed audience segmentation, resulting in a simpler report overview.
  - Removed legacy processing and formatting routines for audience-specific data to enhance clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->