### PR TITLE
Fix: Add pg_terminate_backend to prevent table lock issues

### DIFF
--- a/cron/property.sh
+++ b/cron/property.sh
@@ -7,9 +7,9 @@ psql "$DATABASE_URL" -a  -f /tmp/mi_wayne_detroit.sql > /dev/null
 
 psql "$DATABASE_URL" -c "
 SELECT pg_terminate_backend(pid)
-  FROM pg_stat_activity
-  WHERE query LIKE '%mi_wayne_detroit%'
-  AND pid != pg_backend_pid();
+  FROM pg_locks
+  WHERE relation = to_regclass('address_lookup.mi_wayne_detroit')
+    AND pid != pg_backend_pid();
 DROP TABLE IF EXISTS address_lookup.mi_wayne_detroit;
 CREATE TABLE address_lookup.mi_wayne_detroit (LIKE public.mi_wayne_detroit INCLUDING ALL);
 INSERT INTO address_lookup.mi_wayne_detroit SELECT * FROM public.mi_wayne_detroit;

--- a/cron/property.sh
+++ b/cron/property.sh
@@ -1,13 +1,15 @@
 cd "$(dirname "$0")/.."
 set -a; source .env; set +a
 
-current_date=$(date +%d%m%Y)
-
 psql "$DATABASE_URL" -c "DROP TABLE IF EXISTS public.mi_wayne_detroit;"
 
 psql "$DATABASE_URL" -a  -f /tmp/mi_wayne_detroit.sql > /dev/null
 
 psql "$DATABASE_URL" -c "
+SELECT pg_terminate_backend(pid)
+  FROM pg_stat_activity
+  WHERE query LIKE '%mi_wayne_detroit%'
+  AND pid != pg_backend_pid();
 DROP TABLE IF EXISTS address_lookup.mi_wayne_detroit;
 CREATE TABLE address_lookup.mi_wayne_detroit (LIKE public.mi_wayne_detroit INCLUDING ALL);
 INSERT INTO address_lookup.mi_wayne_detroit SELECT * FROM public.mi_wayne_detroit;

--- a/cron/rental.sh
+++ b/cron/rental.sh
@@ -37,9 +37,9 @@ psql "$DATABASE_URL" -a -f "$FINAL_SQL" > /dev/null
 
 psql "$DATABASE_URL" -c "
 SELECT pg_terminate_backend(pid)
-  FROM pg_stat_activity
-  WHERE query LIKE '%residential_rental_registrations%'
-  AND pid != pg_backend_pid();
+  FROM pg_locks
+  WHERE relation = to_regclass('address_lookup.residential_rental_registrations')
+    AND pid != pg_backend_pid();
 DROP TABLE IF EXISTS address_lookup.residential_rental_registrations;
 CREATE TABLE address_lookup.residential_rental_registrations (LIKE public.rental INCLUDING ALL);
 INSERT INTO address_lookup.residential_rental_registrations SELECT * FROM public.rental;

--- a/cron/rental.sh
+++ b/cron/rental.sh
@@ -36,6 +36,10 @@ psql "$DATABASE_URL" -c "DROP TABLE IF EXISTS public.rental;"
 psql "$DATABASE_URL" -a -f "$FINAL_SQL" > /dev/null
 
 psql "$DATABASE_URL" -c "
+SELECT pg_terminate_backend(pid)
+  FROM pg_stat_activity
+  WHERE query LIKE '%residential_rental_registrations%'
+  AND pid != pg_backend_pid();
 DROP TABLE IF EXISTS address_lookup.residential_rental_registrations;
 CREATE TABLE address_lookup.residential_rental_registrations (LIKE public.rental INCLUDING ALL);
 INSERT INTO address_lookup.residential_rental_registrations SELECT * FROM public.rental;


### PR DESCRIPTION
- Terminate active connections querying mi_wayne_detroit table
- Terminate active connections querying residential_rental_registrations table
- Prevents "table is being accessed by other users" errors during DROP operations
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes table lock issues by terminating active connections before DROP operations in `property.sh` and `rental.sh`.
> 
>   - **Behavior**:
>     - In `property.sh`, terminates active connections to `mi_wayne_detroit` before dropping and recreating the table.
>     - In `rental.sh`, terminates active connections to `residential_rental_registrations` before dropping and recreating the table.
>     - Prevents "table is being accessed by other users" errors during DROP operations.
>   - **Reliability**:
>     - Improves consistency and availability of data during scheduled updates by ensuring tables can be dropped without lock issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PublicDataWorks%2Ftxt-outlier-lookups&utm_source=github&utm_medium=referral)<sup> for 8f418bba29263d5c89ec8361ccbd275975a91b5c. You can [customize](https://app.ellipsis.dev/PublicDataWorks/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Reduced refresh failures by terminating conflicting DB sessions that block Detroit property and rental dataset updates.

- Chores
  - Rebuilds address-lookup tables from the latest public datasets, removes obsolete source tables, and cleans up temporary files.

- Reliability
  - Improves consistency and availability of property and rental data during scheduled updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->