### PR TITLE
Remove windfall profit message

### DIFF
--- a/services/services.py
+++ b/services/services.py
@@ -89,14 +89,15 @@ def search_service(query, conversation_id, to_phone):
     if owner:
         if "LAND BANK" in owner.upper():
             following_messages.append(get_template_content_by_name(FollowingMessageType.LAND_BANK.value))
-    if windfall_profit and windfall_auction_year:
-        template = get_template_content_by_name(FollowingMessageType.WINDFALL.value)
-        message = template.format(
-            address=address,
-            windfall_auction_year=windfall_auction_year,
-            windfall_profit=windfall_profit
-        )
-        following_messages.append(message)
+    # Comment it out as requested here: https://eastagile.slack.com/archives/C052XHL7BSA/p1755722303065449
+    # if windfall_profit and windfall_auction_year:
+    #     template = get_template_content_by_name(FollowingMessageType.WINDFALL.value)
+    #     message = template.format(
+    #         address=address,
+    #         windfall_auction_year=windfall_auction_year,
+    #         windfall_profit=windfall_profit
+    #     )
+    #     following_messages.append(message)
     return handle_match(query_result, conversation_id, to_phone, rental_status, following_messages, tax_status)
 
 

--- a/services/services.py
+++ b/services/services.py
@@ -32,7 +32,6 @@ from models import (
     User,
     LookupTemplate,
     CommentsMentions,
-    PosibleHomeownerWindfall,
 )
 from utils.check_property_status import check_property_status
 
@@ -53,7 +52,7 @@ def search_service(query, conversation_id, to_phone):
     if not results:
         return handle_no_match(display_address, conversation_id, to_phone)
 
-    owner, address, rental_status, tax_status, zip_code, tax_due, windfall_profit, windfall_auction_year = results[0]
+    owner, address, rental_status, tax_status, zip_code, tax_due = results[0]
     if not tax_status and tax_due and int(tax_due) > 0:
         add_data_lookup_to_db(
             address,
@@ -89,15 +88,6 @@ def search_service(query, conversation_id, to_phone):
     if owner:
         if "LAND BANK" in owner.upper():
             following_messages.append(get_template_content_by_name(FollowingMessageType.LAND_BANK.value))
-    # Comment it out as requested here: https://eastagile.slack.com/archives/C052XHL7BSA/p1755722303065449
-    # if windfall_profit and windfall_auction_year:
-    #     template = get_template_content_by_name(FollowingMessageType.WINDFALL.value)
-    #     message = template.format(
-    #         address=address,
-    #         windfall_auction_year=windfall_auction_year,
-    #         windfall_profit=windfall_profit
-    #     )
-    #     following_messages.append(message)
     return handle_match(query_result, conversation_id, to_phone, rental_status, following_messages, tax_status)
 
 
@@ -496,9 +486,7 @@ def query_mi_wayne_detroit(session, address, sunit):
         rental_status_case,
         MiWayneDetroit.tax_status,
         MiWayneDetroit.szip5,
-        MiWayneDetroit.tax_due,
-        PosibleHomeownerWindfall.windfall_profit,
-        PosibleHomeownerWindfall.tax_auction_year,
+        MiWayneDetroit.tax_due
     ).outerjoin(
         ResidentialRentalRegistrations,
         and_(
@@ -513,9 +501,6 @@ def query_mi_wayne_detroit(session, address, sunit):
             ) > 0.8,
             MiWayneDetroit.saddno == ResidentialRentalRegistrations.street_num,
         ),
-    ).outerjoin(
-        PosibleHomeownerWindfall,
-        MiWayneDetroit.parcelnumb == PosibleHomeownerWindfall.parcel_id
     )
 
     if sunit:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Disables windfall profit notifications in `search_service()` by removing related logic and `PosibleHomeownerWindfall` model.
> 
>   - **Behavior**:
>     - Disables windfall profit notifications in `search_service()` in `services.py`.
>     - Removes logic related to `windfall_profit` and `windfall_auction_year`.
>   - **Models**:
>     - Removes `PosibleHomeownerWindfall` model from imports and `query_mi_wayne_detroit()`.
>   - **Misc**:
>     - Adjusts `query_mi_wayne_detroit()` to exclude windfall-related fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PublicDataWorks%2Ftxt-outlier-lookups&utm_source=github&utm_medium=referral)<sup> for dee2cb28ace306f9ab2159751c2527761b3549c6. You can [customize](https://app.ellipsis.dev/PublicDataWorks/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windfall notifications have been disabled. Users will no longer see windfall-related messages in search results or follow-up messages.
  * Other notification types, including Land Bank notifications, remain unchanged and continue to appear as expected.
  * No impact to search inputs or overall workflow; only the windfall message path has been removed from user-facing messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->