### PR TITLE
Read missive_secret from env

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -73,15 +73,13 @@
 
 29. `summary_model`: The AI model used for generating summaries.
 
-30. `missive_secret`: Secret key for Missive API authentication.
+30. `outcome_title`: Title for the impact and outcomes section in convo sidebar.
 
-31. `outcome_title`: Title for the impact and outcomes section in convo sidebar.
+31. `comments_title`: Title for the reporter notes section in convo sidebar.
 
-32. `comments_title`: Title for the reporter notes section in convo sidebar.
+32. `messages_title`: Title for the communication patterns section in convo sidebar.
 
-33. `messages_title`: Title for the communication patterns section in convo sidebar.
-
-34. `number of recipients for each batch`: Update the `no_users` column in the `broadcasts` table for the most recent broadcast (the one with the largest `id`)
+33. `number of recipients for each batch`: Update the `no_users` column in the `broadcasts` table for the most recent broadcast (the one with the largest `id`)
 
 ## 3. Deploy Steps:
 ### Full Flow of Deploying Backend

--- a/libs/MissiveAPI.py
+++ b/libs/MissiveAPI.py
@@ -20,10 +20,9 @@ class MissiveAPI:
     def __init__(self):
         self.email = os.environ.get("EMAIL")
         self.phone_number = os.environ.get("PHONE_NUMBER")
-        self.MISSIVE_SECRET = get_template_content_by_name("missive_secret")
         self.headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.MISSIVE_SECRET}",
+            "Authorization": f"Bearer {os.environ['MISSIVE_SECRET']}",
         }
         self.organization = os.environ.get("MISSIVE_ORGANIZATION")
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change `missive_secret` sourcing in `MissiveAPI` to use environment variables and update `architecture.md` documentation.
> 
>   - **Configuration**:
>     - `MissiveAPI.__init__`: Change `missive_secret` sourcing from `get_template_content_by_name` to `os.environ['MISSIVE_SECRET']`.
>   - **Documentation**:
>     - Remove `missive_secret` from `architecture.md` and adjust numbering for subsequent items.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PublicDataWorks%2Ftxt-outlier-lookups&utm_source=github&utm_medium=referral)<sup> for c7b881ca5f18994236cd93a2a1f3a211c2d7d0c7. You can [customize](https://app.ellipsis.dev/PublicDataWorks/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated configuration key names and ordering for clearer, consistent configuration descriptions.
  * Changed credential sourcing to use system-level secrets directly, simplifying secret handling and improving operational security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->