### PR TITLE
Document EC2 deployment access in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,17 @@ docker build -t lookup .
 docker run -p 5000:5000 --name lookup_app --restart unless-stopped lookup
 ```
 
+## Production Deployment
+
+This is hosted with Docker Compose inside an EC2 instance. To access it:
+
+```bash
+ssh -i Outlier-aws-ec2-key.pem ubuntu@<ec2-host-ip-or-dns>
+cd /home/ubuntu/outlier-experiments
+```
+
+Find the SSH key (`Outlier-aws-ec2-key.pem`) and other credentials in 1Password under `txt-outlier-lookups`.
+
 ## Setup
 ### Prerequisites
 


### PR DESCRIPTION
## Summary
- Add a Production Deployment section to README documenting the SSH command, working directory on the EC2 host, and a pointer to 1Password (`txt-outlier-lookups`) for the SSH key and credentials.

## Test plan
- [x] Render README on GitHub and confirm the new section appears between Docker Quick Start and Setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Production Deployment section to README documenting Docker Compose-based service deployment on EC2 and providing SSH access instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PublicDataWorks/txt-outlier-lookups/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->